### PR TITLE
Add initial Obsidian calculator plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,3 @@ data.json
 
 # Exclude macOS Finder (System Explorer) View States
 .DS_Store
-src/
-node_modules/
-.git/
-tsconfig.json
-package.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# ObCalca
+
+ObCalca is an Obsidian plugin that performs inline calculations using `math.js`.
+Define variables or functions in any markdown document or the global `variables.md` file.
+Use `=>` after an assignment or variable name to evaluate it.
+
+Example:
+```
+x = 10 => 10
+y = x + 5 => 15
+z => 15
+```
+
+Type `@?` to display currently defined variables.

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,10 @@
+{
+  "id": "obcalca",
+  "name": "Obsidian Calculator",
+  "version": "0.0.1",
+  "minAppVersion": "0.12.0",
+  "description": "Inline calculations with math.js",
+  "author": "Codex",
+  "authorUrl": "https://example.com",
+  "isDesktopOnly": false
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "obcalca",
+  "version": "0.0.1",
+  "description": "Obsidian inline calculator plugin",
+  "main": "main.js",
+  "scripts": {
+    "build": "tsc"
+  },
+  "dependencies": {
+    "mathjs": "^11.11.1",
+    "obsidian": "*"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5"
+  },
+  "type": "commonjs"
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,96 @@
+import { App, Plugin, PluginManifest, PluginSettingTab, Setting, Notice, MarkdownPostProcessorContext, TFile } from 'obsidian';
+import { create, all } from 'mathjs';
+
+const math = create(all, {});
+
+interface VariableMap {
+  [name: string]: any;
+}
+
+export default class ObCalcaPlugin extends Plugin {
+  private variables: VariableMap = {};
+  private functions: VariableMap = {};
+
+  async onload() {
+    await this.loadVariablesFile();
+
+    this.registerMarkdownPostProcessor((el, ctx) => this.processCode(el, ctx));
+
+    this.registerDomEvent(document, 'keyup', (evt: KeyboardEvent) => {
+      if (evt.key === '?' && evt.shiftKey && (evt.ctrlKey || evt.metaKey)) {
+        this.showVariables();
+      }
+    });
+  }
+
+  onunload() {
+    // Nothing special
+  }
+
+  private async loadVariablesFile() {
+    const file = this.app.vault.getAbstractFileByPath('variables.md');
+    if (file instanceof TFile) {
+      const data = await this.app.vault.read(file);
+      this.parseLines(data.split(/\r?\n/));
+    }
+  }
+
+  private processCode(el: HTMLElement, ctx: MarkdownPostProcessorContext) {
+    const lines = el.innerText.split(/\r?\n/);
+    const processed = this.parseLines(lines);
+    el.innerHTML = processed.join('\n');
+  }
+
+  private parseLines(lines: string[]): string[] {
+    const result: string[] = [];
+
+    for (let line of lines) {
+      const evalIndex = line.indexOf('=>');
+      if (evalIndex !== -1) {
+        line = line.substring(0, evalIndex).trim();
+      }
+
+      const assignMatch = line.match(/^(\w+)\s*=\s*(.+)$/);
+      if (assignMatch) {
+        const name = assignMatch[1];
+        const expr = assignMatch[2];
+        try {
+          const value = math.evaluate(expr, { ...this.variables, ...this.functions });
+          this.variables[name] = value;
+          result.push(`${line} => ${value}`);
+        } catch (e) {
+          result.push(`${line} => Error`);
+        }
+        continue;
+      }
+
+      const funcMatch = line.match(/^(\w+)\(([^)]*)\)\s*=\s*(.+)$/);
+      if (funcMatch) {
+        const name = funcMatch[1];
+        const params = funcMatch[2].split(',').map(p => p.trim());
+        const expr = funcMatch[3];
+        this.functions[name] = (...args: any[]) => {
+          const scope: any = { ...this.variables };
+          params.forEach((p, i) => scope[p] = args[i]);
+          return math.evaluate(expr, { ...scope, ...this.functions });
+        };
+        result.push(line);
+        continue;
+      }
+
+      if (evalIndex !== -1) {
+        const name = line.trim();
+        const value = this.variables[name];
+        result.push(`${name} => ${value}`);
+      } else {
+        result.push(line);
+      }
+    }
+    return result;
+  }
+
+  private showVariables() {
+    const lines = Object.entries(this.variables).map(([k, v]) => `${k} = ${v}`);
+    new Notice(lines.join('\n') || 'No variables defined');
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "lib": ["ES2020"],
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}

--- a/variables.md
+++ b/variables.md
@@ -1,0 +1,4 @@
+# Global Variables and Functions
+
+x = 10
+foo(a,b) = a^2 + b / 10


### PR DESCRIPTION
## Summary
- implement initial plugin skeleton in TypeScript
- provide manifest and build configuration
- document usage in README
- add a variables.md file for shared variables
- adjust gitignore and tsconfig

## Testing
- `npm run build` *(fails: No inputs were found in config file)*

------
https://chatgpt.com/codex/tasks/task_b_688c7318bdcc833388645d5b589e5998