### PR TITLE
Fix typescript compile errors

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { App, Plugin, PluginManifest, PluginSettingTab, Setting, Notice, MarkdownPostProcessorContext, TFile } from 'obsidian';
+import { App, Plugin, PluginManifest, PluginSettingTab, Setting, Notice, MarkdownPostProcessorContext, MarkdownView, TFile } from 'obsidian';
 import { create, all } from 'mathjs';
 
 const math = create(all, {});
@@ -126,7 +126,7 @@ export default class ObCalcaPlugin extends Plugin {
 
     private async evaluateActiveFile() {
         const view = this.app.workspace.getActiveViewOfType(MarkdownView);
-        if (!view) return;
+        if (!view || !(view.file instanceof TFile)) return;
         const file = view.file;
         const text = await this.app.vault.read(file);
         const { lines, vars } = this.parseDocument(text);
@@ -141,91 +141,3 @@ export default class ObCalcaPlugin extends Plugin {
     }
 
 }
-
-export default class ObCalcaPlugin extends Plugin {
-  private variables: VariableMap = {};
-  private functions: VariableMap = {};
-
-  async onload() {
-    await this.loadVariablesFile();
-
-    this.registerMarkdownPostProcessor((el, ctx) => this.processCode(el, ctx));
-
-    this.registerDomEvent(document, 'keyup', (evt: KeyboardEvent) => {
-      if (evt.key === '?' && evt.shiftKey && (evt.ctrlKey || evt.metaKey)) {
-        this.showVariables();
-      }
-    });
-  }
-
-  onunload() {
-    // Nothing special
-  }
-
-  private async loadVariablesFile() {
-    const file = this.app.vault.getAbstractFileByPath('variables.md');
-    if (file instanceof TFile) {
-      const data = await this.app.vault.read(file);
-      this.parseLines(data.split(/\r?\n/));
-    }
-  }
-
-  private processCode(el: HTMLElement, ctx: MarkdownPostProcessorContext) {
-    const lines = el.innerText.split(/\r?\n/);
-    const processed = this.parseLines(lines);
-    el.innerHTML = processed.join('\n');
-  }
-
-  private parseLines(lines: string[]): string[] {
-    const result: string[] = [];
-
-    for (let line of lines) {
-      const evalIndex = line.indexOf('=>');
-      if (evalIndex !== -1) {
-        line = line.substring(0, evalIndex).trim();
-      }
-
-      const assignMatch = line.match(/^(\w+)\s*=\s*(.+)$/);
-      if (assignMatch) {
-        const name = assignMatch[1];
-        const expr = assignMatch[2];
-        try {
-          const value = math.evaluate(expr, { ...this.variables, ...this.functions });
-          this.variables[name] = value;
-          result.push(`${line} => ${value}`);
-        } catch (e) {
-          result.push(`${line} => Error`);
-        }
-        continue;
-      }
-
-      const funcMatch = line.match(/^(\w+)\(([^)]*)\)\s*=\s*(.+)$/);
-      if (funcMatch) {
-        const name = funcMatch[1];
-        const params = funcMatch[2].split(',').map(p => p.trim());
-        const expr = funcMatch[3];
-        this.functions[name] = (...args: any[]) => {
-          const scope: any = { ...this.variables };
-          params.forEach((p, i) => scope[p] = args[i]);
-          return math.evaluate(expr, { ...scope, ...this.functions });
-        };
-        result.push(line);
-        continue;
-      }
-
-      if (evalIndex !== -1) {
-        const name = line.trim();
-        const value = this.variables[name];
-        result.push(`${name} => ${value}`);
-      } else {
-        result.push(line);
-      }
-    }
-    return result;
-  }
-
-  private showVariables() {
-    const lines = Object.entries(this.variables).map(([k, v]) => `${k} = ${v}`);
-    new Notice(lines.join('\n') || 'No variables defined');
-  }
-

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "CommonJS",
-    "lib": ["ES2020"],
+    "lib": ["ES2020", "DOM"],
     "declaration": true,
     "outDir": "dist",
     "rootDir": "src",


### PR DESCRIPTION
## Summary
- include DOM libs for TypeScript so `document` and `KeyboardEvent` are recognized
- remove duplicate unfinished plugin implementation
- guard against null `view.file` when evaluating the document

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688d3a75a7b88333848936d1c77f3c6e