### PR TITLE
Enable automatic evaluation when typing `=>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,5 @@ y = x + 5 => 15
 z => 15
 ```
 Run **Evaluate Document** from the command palette to update all evaluations.
+Evaluations also run automatically when you type the `=>` token at the end of a line.
 Typing `@?` in the editor will display all current variables in a popup.

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,19 @@ export default class ObCalcaPlugin extends Plugin {
                 }
             }
         });
+
+        this.registerDomEvent(document, 'keyup', async (evt: KeyboardEvent) => {
+            if (evt.key === '>') {
+                const view = this.app.workspace.getActiveViewOfType(MarkdownView);
+                if (!view) return;
+                const editor = view.editor;
+                const cursor = editor.getCursor();
+                const line = editor.getLine(cursor.line);
+                if (cursor.ch >= 2 && line.substring(cursor.ch - 2, cursor.ch) === '=>') {
+                    await this.evaluateActiveFile();
+                }
+            }
+        });
     }
 
     private async loadVariablesFile() {


### PR DESCRIPTION
## Summary
- trigger document evaluation when `=>` token is typed
- document automatic evaluation behavior in README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688d48fe051c8333ac6e932a8780b6d1