### PR TITLE
Remove styling to focus on functionality

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -145,7 +145,6 @@ export default class ObCalcaPlugin extends Plugin {
         evals.forEach((value, line) => {
             const span = document.createElement('span');
             span.textContent = ` ${value}`;
-            span.className = 'obcalca-eval';
             const mark = cm.setBookmark({ line, ch: cm.getLine(line).length }, { widget: span });
             this.resultMarks.push(mark);
         });

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,0 @@
-.obcalca-eval {
-  color: var(--text-success);
-}


### PR DESCRIPTION
## Summary
- drop `.obcalca-eval` styling class and remove styles.css to eliminate UI concerns
- keep result rendering minimal by only showing calculated value

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6892464b3434833385e629b9bb975a15