### PR TITLE
Add summation token

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 ObCalca is an Obsidian plugin that performs inline calculations anywhere in a
 markdown file using `math.js`. Define variables or functions in the current
 note or in the global `variables.md` file. Each line ending with `=>`
-automatically displays its value as you edit. Results appear in green after the
-arrow and are not saved to the document, so they remain read-only.
+automatically displays its value as you edit. Lines ending with `=+>` show the
+sum of all numeric results since the previous `=+>` token. Results appear in
+green after the arrow and are not saved to the document, so they remain read-only.
 
+```
 x = 10 => 10
 y = x + 5 => 15
-z => 15
+=+> 25
 ```
 Documents are re-evaluated automatically whenever a line changes. You can also
 run **Evaluate Document** from the command palette to force an update.


### PR DESCRIPTION
## Summary
- add `=+>` token to sum numeric results since the previous summation token
- evaluate `=+>` lines immediately like `=>`
- document summation token usage in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: sh: 1: Syntax error: Unterminated quoted string)*


------
https://chatgpt.com/codex/tasks/task_b_6893c2079bf0833399c312b28f506ee3